### PR TITLE
Add South Sudan according to ISO Newsletter VI-10

### DIFF
--- a/lib/country-select.rb
+++ b/lib/country-select.rb
@@ -51,7 +51,7 @@ module ActionView
         "Saint Pierre and Miquelon", "Saint Vincent and the Grenadines", "Samoa", "San Marino",
         "Sao Tome and Principe", "Saudi Arabia", "Senegal", "Serbia", "Seychelles", "Sierra Leone", "Singapore",
         "Slovakia", "Slovenia", "Solomon Islands", "Somalia", "South Africa",
-        "South Georgia and the South Sandwich Islands", "Spain", "Sri Lanka", "Sudan", "Suriname",
+        "South Georgia and the South Sandwich Islands", "South Sudan", "Spain", "Sri Lanka", "Sudan", "Suriname",
         "Svalbard and Jan Mayen", "Swaziland", "Sweden", "Switzerland", "Syrian Arab Republic",
         "Taiwan, Province of China", "Tajikistan", "Tanzania, United Republic of", "Thailand", "Timor-Leste",
         "Togo", "Tokelau", "Tonga", "Trinidad and Tobago", "Tunisia", "Turkey", "Turkmenistan",


### PR DESCRIPTION
See http://www.iso.org/iso/nl_vi-10_south_sudan.pdf

There are more new countries at http://www.iso.org/iso/support/country_codes/iso_3166_code_lists/iso-3166-1_decoding_table.htm :-)
