### PR TITLE
Update Name For Macedonia

### DIFF
--- a/lib/country-select.rb
+++ b/lib/country-select.rb
@@ -295,7 +295,6 @@ module ActionView
       def to_country_select_tag(priority_countries, options, html_options)
         html_options = html_options.stringify_keys
         add_default_name_and_id(html_options)
-        value = value(object)
         content_tag("select",
 
           add_options(

--- a/lib/country-select.rb
+++ b/lib/country-select.rb
@@ -170,7 +170,7 @@ module ActionView
         "Lithuania",
         "Luxembourg",
         "Macao",
-        "Macedonia, Republic Of",
+        "Republic of North Macedonia",
         "Madagascar",
         "Malawi",
         "Malaysia",


### PR DESCRIPTION
Earlier this year the Macedonian Government renamed the country from
"Republic of Macedonia" to "Republic of North Macedonia". This PR updates the country name accordingly.

https://www.bbc.co.uk/news/world-europe-46846231